### PR TITLE
mtb-makefile.mk: Multi program moved to port Makefile.

### DIFF
--- a/mtb-makefile.mk
+++ b/mtb-makefile.mk
@@ -39,31 +39,18 @@ mtb_clean:
 	-$(Q) $(MAKE) -C $(MTB_LIBS_DIR) clean
 	-$ rm -rf $(MTB_LIBS_BUILD_DIR)
 
-# When multiple types of boards are connected, a devs file needs to be provided.
-# When working locally, if a "local-devs.yml" file is placed in "tools/psoc6"
-# it will be used
-ifneq ($(DEVS_FILE),)
-MULTI_BOARD_DEVS_OPTS = -b $(BOARD) -y $(DEVS_FILE)
-else 
-DFLT_LOCAL_DEVS_FILE_NAME = local-devs.yml
-LOCAL_DEVS_FILE=$(TOP)/tools/psoc6/$(DFLT_LOCAL_DEVS_FILE_NAME)
-ifneq (,$(wildcard $(LOCAL_DEVS_FILE)))
-MULTI_BOARD_DEVS_OPTS = -b $(BOARD) -y $(LOCAL_DEVS_FILE)
-endif
-endif
-
-attached_devs:
-	@:
-	$(eval ATTACHED_TARGET_LIST = $(shell $(PYTHON) $(TOP)/lib/mpy-test-ext/get_devs.py serial-number $(MULTI_BOARD_DEVS_OPTS)))
-	$(eval ATTACHED_TARGETS_NUMBER = $(words $(ATTACHED_TARGET_LIST)))
-	$(info Number of attached targets : $(ATTACHED_TARGETS_NUMBER))
-	$(info List of attached targets : $(ATTACHED_TARGET_LIST))
 
 ifndef EXT_HEX_FILE
 HEX_FILE = $(BUILD)/firmware.hex
 PROG_DEPS=$(BUILD)
 else
 HEX_FILE = $(EXT_HEX_FILE)
+endif
+
+ifndef DEV_SERIAL_NUMBER
+SERIAL_ADAPTER_CMD =
+else
+SERIAL_ADAPTER_CMD = adapter serial $(DEV_SERIAL_NUMBER)
 endif
 
 MTB_HOME     ?= $(HOME)/ModusToolbox
@@ -79,10 +66,6 @@ mtb_program: $(PROG_DEPS)
 	openocd -s $(OPENOCD_HOME)/scripts -s $(OPENOCD_CFG_SEARCH) -c "source [find interface/kitprog3.cfg]; $(SERIAL_ADAPTER_CMD) ; source [find target/$(OPENOCD_TARGET_CFG)]; psoc6 allow_efuse_program off; psoc6 sflash_restrictions 1; program $(HEX_FILE) verify reset exit;"
 	$(info Programming done.)
 
-mtb_program_multi: attached_devs
-	@:
-	$(foreach ATTACHED_TARGET, $(ATTACHED_TARGET_LIST), $(MAKE) qdeploy SERIAL_ADAPTER_CMD='adapter serial $(ATTACHED_TARGET)';)
-
 mtb_build_help:
 	@:
 	$(info )
@@ -91,12 +74,12 @@ mtb_build_help:
 	$(info 	mtb_build               Build the mtb psoc6 lib project)
 	$(info  mtb_get_build_flags     Retrieve build flags for mtb psoc6 lib build)
 	$(info 	mtb_program             Program the built firmware to the connected board.)
-	$(info 	mtb_program_multi       Program multiple connected boards of the same type.)
 	$(info  Options: )
 	$(info  - EXT_HEX_FILE          An external .hex file can be provided to the program )
 	$(info  ..                      targets, instead of building from the sources.)
+	$(info  - DEV_SERIAL_NUMBER     Serial number of the target to program when multiple devices are connected.)
 	$(info 	mtb_clean               Clean the ModusToolbox build files)
 	$(info 	mtb_build_help          Show this help message)
 	$(info )
 
-.PHONY: mtb_build mtb_get_build_flags mtb_program mtb_program_multi attached_devs mtb_clean mtb_build_help
+.PHONY: mtb_build mtb_get_build_flags mtb_program attached_devs mtb_clean mtb_build_help


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Multi target is now moved to the main project, simplifying the dependency with the device management tool  from mpy-test-ext